### PR TITLE
[master] thermal: Add backlight burnout protection

### DIFF
--- a/rootdir/vendor/etc/thermanager.xml
+++ b/rootdir/vendor/etc/thermanager.xml
@@ -61,6 +61,9 @@
         <!-- shutdown -->
         <resource name="shutdown" type="halt" delay="5" />
 
+        <!-- display backlight -->
+        <resource name="disp-bl" type="sysfs">/sys/class/leds/lcd-backlight/max_brightness</resource>
+
         <!-- CPU temperature -->
         <resource name="cluster-0-temp" type="union">
             <resource name="tsens_tz_sensor1" />
@@ -132,6 +135,14 @@
         <mitigation level="5"><value resource="charge_speed">11</value></mitigation>
         <mitigation level="6"><value resource="charge_speed">12</value></mitigation>
         <mitigation level="7"><value resource="charge_speed">13</value></mitigation>
+    </control>
+	
+    <control name="backlight">
+        <mitigation level="off"><value resource="disp-bl">4095</value></mitigation>
+        <mitigation level="1"><value resource="disp-bl">3531</value></mitigation>
+        <mitigation level="2"><value resource="disp-bl">2728</value></mitigation>
+        <mitigation level="3"><value resource="disp-bl">1930</value></mitigation>
+        <mitigation level="4"><value resource="disp-bl">1000</value></mitigation>
     </control>
 
     <!-- CPU temperature protection - Values in deci-centigrade -->
@@ -253,6 +264,25 @@
         </threshold>
         <threshold trigger="740" clear="630">
             <mitigation name="shutdown" level="1" />
+        </threshold>
+    </configuration>
+
+    <!-- display backlight burnout protection - deci-centigrade -->
+    <configuration sensor="msm_therm">
+        <threshold>
+            <mitigation name="backlight" level="off" />
+        </threshold>
+        <threshold trigger="420" clear="400">
+            <mitigation name="backlight" level="1" />
+        </threshold>
+        <threshold trigger="440" clear="420">
+            <mitigation name="backlight" level="2" />
+        </threshold>
+        <threshold trigger="480" clear="450">
+            <mitigation name="backlight" level="3" />
+        </threshold>
+        <threshold trigger="550" clear="500">
+            <mitigation name="backlight" level="4" />
         </threshold>
     </configuration>
 


### PR DESCRIPTION
Under certain heat conditions, it is possible to burn the backlight
LEDs and/or controller.
Mitigate backlight values to prevent burnout.