### PR TITLE
[DISCOVERY] vendor: libnfc-nxp: Change device node to pn54x

### DIFF
--- a/rootdir/vendor/etc/libnfc-nxp.conf
+++ b/rootdir/vendor/etc/libnfc-nxp.conf
@@ -19,7 +19,7 @@ NXPLOG_TML_LOGLEVEL=0x03
 
 ###############################################################################
 # Nfc Device Node name
-NXP_NFC_DEV_NODE="/dev/pn553"
+NXP_NFC_DEV_NODE="/dev/pn54x"
 
 ###############################################################################
 # Extension for Mifare reader enable


### PR DESCRIPTION
Open Devices kernel uses the pn547 driver that spawns a device
accessible at /dev/pn54x.

