### PR TITLE
discovery: rename NXP HAL

### DIFF
--- a/rootdir/vendor/etc/libnfc-brcm.conf
+++ b/rootdir/vendor/etc/libnfc-brcm.conf
@@ -367,7 +367,7 @@ NFA_MAX_EE_SUPPORTED=0x03
 
 ###############################################################################
 # NCI Hal Module name
-NCI_HAL_MODULE="nfc_nci.pn54x"
+NCI_HAL_MODULE="nfc_nci"
 
 ##############################################################################
 # Deactivate notification wait time out in seconds used in ETSI Reader mode


### PR DESCRIPTION
nfc_nci.discovery.so not nfc_nci.pn54x.so

Signed-off-by: David Viteri <davidteri91@gmail.com>