### PR TITLE
add logic to set TARGET_BOOTLOADER_BOARD_NAME

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -14,7 +14,14 @@
 
 include device/sony/nile/PlatformConfig.mk
 
-TARGET_BOOTLOADER_BOARD_NAME := nile
+TARGET_BOOTLOADER_BOARD_NAME := unknown
+ifneq (,$(filter %h3213,$(TARGET_PRODUCT)))
+TARGET_BOOTLOADER_BOARD_NAME := H3213
+else ifneq (,$(filter %h4213,$(TARGET_PRODUCT)))
+TARGET_BOOTLOADER_BOARD_NAME := H4213
+else
+$(error Unrecognized value for TARGET_PRODUCT: "$(TARGET_PRODUCT)")
+endif
 
 # Platform
 PRODUCT_PLATFORM := nile


### PR DESCRIPTION
Set TARGET_BOOTLOADER_BOARD_NAME to the variant-specific board-name
(i.e. H3213, H4213).  This causes the "board" variable in
"android-info.txt" to be populated correctly, which fixes
updatepackage zips.