### PR TITLE
Remove unnecessary NFC flags and packages

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -28,7 +28,6 @@ endif
 PRODUCT_PLATFORM := nile
 
 # NFC
-NXP_CHIP_TYPE := PN553
 NXP_CHIP_FW_TYPE := PN553
 
 BOARD_KERNEL_CMDLINE += androidboot.hardware=discovery

--- a/device.mk
+++ b/device.mk
@@ -73,10 +73,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PACKAGES += \
     power.discovery
 
-# NFC config
-PRODUCT_PACKAGES += \
-    nfc_nci.discovery
-
 # Telephony Packages (AOSP)
 PRODUCT_PACKAGES += \
     InCallUI \


### PR DESCRIPTION
* These packages and flags no longer exist
  in AOSP 9 codebase.